### PR TITLE
revert: Use pretty path in EasyAdmin

### DIFF
--- a/config/routes/easyadmin.yaml
+++ b/config/routes/easyadmin.yaml
@@ -1,3 +1,0 @@
-easyadmin:
-  resource: .
-  type: easyadmin.routes

--- a/src/Controller/Admin/DashboardController.php
+++ b/src/Controller/Admin/DashboardController.php
@@ -18,15 +18,23 @@ use App\Entity\User;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Dashboard;
 use EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractDashboardController;
+use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGenerator;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
 class DashboardController extends AbstractDashboardController
 {
+    public function __construct(
+        private readonly AdminUrlGenerator $adminUrlGenerator,
+    ) {
+    }
+
     #[Route('/admin', name: 'admin')]
     public function index(): Response
     {
-        return $this->redirectToRoute('admin_user_index');
+        return $this->redirect(
+            $this->adminUrlGenerator->setController(UserCrudController::class)->generateUrl()
+        );
     }
 
     public function configureDashboard(): Dashboard

--- a/src/EventSubscriber/FeedbackCreatedListenerSubscriber.php
+++ b/src/EventSubscriber/FeedbackCreatedListenerSubscriber.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 namespace App\EventSubscriber;
 
+use App\Controller\Admin\FeedbackCrudController;
 use App\Entity\Feedback;
 use Doctrine\Bundle\DoctrineBundle\Attribute\AsEntityListener;
 use Doctrine\ORM\Events;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
+use EasyCorp\Bundle\EasyAdminBundle\Router\AdminUrlGenerator;
 use Symfony\Component\Notifier\Notification\Notification;
 use Symfony\Component\Notifier\NotifierInterface;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
-use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 #[AsEntityListener(event: Events::postPersist, method: 'onFeedbackCreated', entity: Feedback::class)]
@@ -19,7 +20,7 @@ final readonly class FeedbackCreatedListenerSubscriber
     public function __construct(
         private NotifierInterface $notifier,
         private TranslatorInterface $translator,
-        private RouterInterface $router,
+        private AdminUrlGenerator $adminUrlGenerator,
     ) {
     }
 
@@ -32,9 +33,11 @@ final readonly class FeedbackCreatedListenerSubscriber
             '%account%' => $feedback->getSender()?->getUserIdentifier()
                 ?? $this->translator->trans('notification.on-feedback-created.anonymous'),
             '%subject%' => $feedback->getTitle(),
-            '%link%' => $this->router->generate('admin_feedback_detail', [
-                'entityId' => $feedback->getId(),
-            ], UrlGeneratorInterface::ABSOLUTE_URL),
+            '%link%' => $this->adminUrlGenerator->unsetAll()
+                ->setController(FeedbackCrudController::class)
+                ->setAction(Action::DETAIL)
+                ->setEntityId($feedback->getId())
+                ->generateUrl(),
         ]);
 
         $this->notifier->send((new Notification($notificationContent))->channels(['chat/linenotify']));


### PR DESCRIPTION
Incompatible with FrankenPHP currently :(

For reference, the error is (when opening from dashboard page):

```
EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController::index(): Argument #1 ($context) must be of type EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext, null given, called in /app/vendor/symfony/http-kernel/HttpKernel.php on line 183 (/app/vendor/easycorp/easyadmin-bundle/src/Controller/AbstractCrudController.php:117)

#0 /app/vendor/symfony/http-kernel/HttpKernel.php(183): EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController->index()
#1 /app/vendor/symfony/http-kernel/HttpKernel.php(76): Symfony\Component\HttpKernel\HttpKernel->handleRaw()
#2 /app/vendor/symfony/http-kernel/Kernel.php(182): Symfony\Component\HttpKernel\HttpKernel->handle()
#3 /app/vendor/runtime/frankenphp-symfony/src/Runner.php(38): Symfony\Component\HttpKernel\Kernel->handle()
#4 [internal function]: Runtime\FrankenPhpSymfony\Runner->Runtime\FrankenPhpSymfony\{closure}()
#5 /app/vendor/runtime/frankenphp-symfony/src/Runner.php(45): frankenphp_handle_request()
#6 /app/vendor/autoload_runtime.php(29): Runtime\FrankenPhpSymfony\Runner->run()
#7 /app/public/index.php(5): require_once('...')
#8 {main}
```

This reverts commit 7e2f1b44d379c8648f36c99fefc8e2f21ed89ec6.
